### PR TITLE
shpeito network filters - internships and classes prefix

### DIFF
--- a/src/components/FilterSelection.js
+++ b/src/components/FilterSelection.js
@@ -24,6 +24,7 @@ function FilterSelection(props) {
     graduating: [],
     country: [],
     classes: [],
+    internships: [],
   });
   const [filterVal, setFilterVal] = useState("");
 
@@ -45,6 +46,7 @@ function FilterSelection(props) {
     Graduating: graduating,
     Country: country,
     Classes: "",
+    Internships: "",
   };
 
   function addFilter() {

--- a/src/pages/ShpeitoNetwork.js
+++ b/src/pages/ShpeitoNetwork.js
@@ -11,7 +11,7 @@ import {
   Responsive,
 } from "semantic-ui-react";
 import { useQuery } from "@apollo/react-hooks";
-import { FETCH_USERS_QUERY } from "../util/graphql"
+import { FETCH_USERS_QUERY } from "../util/graphql";
 
 import Title from "../components/Title";
 import FilterSelection from "../components/FilterSelection";
@@ -27,6 +27,7 @@ function ShpeitoNetwork(props) {
       graduating: [],
       country: [],
       classes: [],
+      internships: [],
     })
   );
 
@@ -42,6 +43,8 @@ function ShpeitoNetwork(props) {
   if (!loading && data) {
     users = data.getUsers.filter(function (user) {
       let fullName = user.firstName.concat(" ").concat(user.lastName);
+      let allInternships = user.internships.toString();
+      let allClasses = user.classes.toString();
       return (
         user.confirmed &&
         (filter.major.length === 0
@@ -54,9 +57,18 @@ function ShpeitoNetwork(props) {
         (filter.country.length === 0
           ? true
           : filter.country.includes(user.country)) &&
+        (filter.internships.length === 0
+          ? true
+          : filter.internships
+              .map((n) =>
+                allInternships.toLowerCase().includes(n.toLowerCase())
+              )
+              .includes(true)) &&
         (filter.classes.length === 0
           ? true
-          : filter.classes.some((o) => user.classes.includes(o))) &&
+          : filter.classes
+              .map((n) => allClasses.toLowerCase().includes(n.toLowerCase()))
+              .includes(true)) &&
         (filter.name.length === 0
           ? true
           : filter.name
@@ -213,6 +225,7 @@ class Filter {
     this.graduating = filter.graduating;
     this.country = filter.country;
     this.classes = filter.classes;
+    this.internships = filter.internships;
   }
 }
 


### PR DESCRIPTION
### Summary

my pr now has the internship filter on the shpeito network to search for internships amongst users even if it's not exactly capitalized the same so microsoft, Microsoft, and microSoft will all work. It will also use the include function so if I search for Procter, and the user has Procter & Gamble - Intern Management etc, it will still yield the user. For the classes filter, if I search for COP or CDA or any other class prefix, if a user has inputted a class such as COP4600 or CDA3101, the filter will yield those users.

### Reference

https://app.asana.com/0/1202843173947642/1203195660566592

### Extra

_please add me (@yairtemkin) as a reviewer. thank u_
