### PR TITLE
Separating Admin Panel events by semester

### DIFF
--- a/src/components/EventsAccordion.js
+++ b/src/components/EventsAccordion.js
@@ -1,0 +1,54 @@
+import React from "react";
+import { Segment, Header, Tab } from "semantic-ui-react";
+import EventsTable from "../components/EventsTable.js";
+
+function EventsAccordion({ events }){
+
+  let fallSem = [];
+  let springSem = [];
+  let summerSem = [];
+
+  let tab1;
+  let tab2;
+  let tab3;
+
+  if (events){
+      events.map((event, index) => (
+        fallSem = events.filter(event => event.semester =='Fall Semester'),
+        springSem = events.filter(event => event.semester =='Spring Semester'),
+        summerSem = events.filter(event => event.semester =='Summer Semester')
+
+  ))
+
+  tab1 = EventsTable(fallSem)
+  tab2 = EventsTable(springSem)
+  tab3 = EventsTable(summerSem)
+}
+
+
+  const panes = [
+  { menuItem: 'Fall Semester', render: () => <Tab.Pane><EventsTable events={fallSem} /></Tab.Pane> },
+  { menuItem: 'Spring Semester', render: () => <Tab.Pane><EventsTable events={springSem} /></Tab.Pane> },
+  { menuItem: 'Summer Semester', render: () => <Tab.Pane><EventsTable events={summerSem} /></Tab.Pane> },
+  ]
+
+
+  return(
+    <>
+    {events === undefined ? (
+      <Segment placeholder>
+        <Header icon>
+          <i className="fas fa-inbox"></i>
+          <p>It seems like there are no events at this moment.</p>
+        </Header>
+      </Segment>
+    ) : (
+    <Tab panes={panes} />
+  )
+
+}
+</>
+)
+}
+
+export default EventsAccordion;

--- a/src/components/EventsTable.js
+++ b/src/components/EventsTable.js
@@ -1,5 +1,6 @@
 import React, { useState } from "react";
 import {
+  Accordion,
   Table,
   Icon,
   Dimmer,
@@ -25,23 +26,11 @@ function EventsTable({ events }) {
   const [eventAttendance, setEventAttendance] = useState({});
   const [selectedEvent, setSelectedEvent] = useState("");
 
-  const fallSem = [];
-  const springSem = [];
-  const summerSem = [];
+  const eventsNoUsers = events ? events.map(({ users, ...item }) => item) : [];
 
   const [removeUserFromEvent] = useMutation(REMOVE_USER_MUTATION, {
     update(cache, { data: { removeUserFromEvent } }) {
       const { getEvents } = cache.readQuery({ query: FETCH_EVENTS_QUERY });
-
-      getEvents.forEach((event, pos) => {
-        if (event.semester === "Fall Semester") fallSem.push(event);
-      });
-      getEvents.forEach((event, pos) => {
-        if (event.semester === "Spring Semester") springSem.push(event);
-      });
-      getEvents.forEach((event, pos) => {
-        if (event.semester === "Summer Semester") summerSem.push(event);
-      });
 
       getEvents.forEach((event, pos) => {
         if (event.name === removeUserFromEvent.name)
@@ -54,6 +43,11 @@ function EventsTable({ events }) {
       setSelectedEvent(removeUserFromEvent.name);
     },
   });
+
+  if (typeof events != "undefined") {
+    events.map((event, index) => console.log(event.semester));
+  }
+
   function populateCSV(users) {
     if (!users) return null;
     let list = [];
@@ -80,86 +74,105 @@ function EventsTable({ events }) {
         </Segment>
       ) : (
         <div className="table-responsive">
-          <Table striped selectable unstackable>
-            <Table.Header>
-              <Table.Row>
-                <Table.HeaderCell>Name</Table.HeaderCell>
-                <Table.HeaderCell>Category</Table.HeaderCell>
-                <Table.HeaderCell>Expiration</Table.HeaderCell>
-                <Table.HeaderCell>Semester</Table.HeaderCell>
-                <Table.HeaderCell textAlign="center">Request</Table.HeaderCell>
-                <Table.HeaderCell textAlign="center">
-                  Attendance
-                </Table.HeaderCell>
-                <Table.HeaderCell textAlign="center">Points</Table.HeaderCell>
-                <Table.HeaderCell textAlign="center">
-                  Manual Input
-                </Table.HeaderCell>
-                <Table.HeaderCell textAlign="center">Info</Table.HeaderCell>
-                <Table.HeaderCell textAlign="center">Delete</Table.HeaderCell>
-              </Table.Row>
-            </Table.Header>
-            <Table.Body>
-              {events &&
-                events.map((event, index) => (
-                  <Table.Row key={index}>
-                    <Table.Cell>{event.name}</Table.Cell>
-                    <Table.Cell>{event.category}</Table.Cell>
-                    <Table.Cell>
-                      {moment(event.expiration)
-                        .local()
-                        .format("MM/DD/YYYY @ hh:mm A")}
-                    </Table.Cell>
-                    <Table.Cell>{event.semester}</Table.Cell>
-                    <Table.Cell textAlign="center">
-                      {event.request === true ? (
-                        <Icon className="request-true" name="check" />
-                      ) : (
-                        <Icon className="request-false" name="x" />
-                      )}
-                    </Table.Cell>
-                    <Table.Cell textAlign="center">
-                      {event.attendance}
-                    </Table.Cell>
-                    <Table.Cell textAlign="center">{event.points}</Table.Cell>
-                    <Table.Cell textAlign="center">
-                      <Button
-                        icon
-                        onClick={() => {
-                          setSelectedEvent(event.name);
-                          setManualInputModal(true);
-                        }}
-                      >
-                        <Icon name="i cursor" />
-                      </Button>
-                    </Table.Cell>
-                    <Table.Cell textAlign="center">
-                      <Button
-                        icon
-                        onClick={() => {
-                          setEventAttendance(event);
-                          setEventInfoModal(true);
-                        }}
-                      >
-                        <Icon name="info" />
-                      </Button>
-                    </Table.Cell>
-                    <Table.Cell textAlign="center">
-                      <Button
-                        icon
-                        onClick={() => {
-                          setSelectedEvent(event.name);
-                          setDeleteEventModal(true);
-                        }}
-                        color="red"
-                      >
-                        <Icon name="x" />
-                      </Button>
-                    </Table.Cell>
+          <Grid>
+            <Grid.Row>
+              <Table striped selectable unstackable>
+                <Table.Header>
+                  <Table.Row>
+                    <Table.HeaderCell>Name</Table.HeaderCell>
+                    <Table.HeaderCell>Category</Table.HeaderCell>
+                    <Table.HeaderCell>Expiration</Table.HeaderCell>
+                    <Table.HeaderCell>Semester</Table.HeaderCell>
+                    <Table.HeaderCell textAlign="center">
+                      Request
+                    </Table.HeaderCell>
+                    <Table.HeaderCell textAlign="center">
+                      Attendance
+                    </Table.HeaderCell>
+                    <Table.HeaderCell textAlign="center">
+                      Points
+                    </Table.HeaderCell>
+                    <Table.HeaderCell textAlign="center">
+                      Manual Input
+                    </Table.HeaderCell>
+                    <Table.HeaderCell textAlign="center">Info</Table.HeaderCell>
+                    <Table.HeaderCell textAlign="center">
+                      Delete
+                    </Table.HeaderCell>
                   </Table.Row>
-                ))}
-            </Table.Body>
-          </Table>
+                </Table.Header>
+                <Table.Body>
+                  {events &&
+                    events.map((event, index) => (
+                      <Table.Row key={index}>
+                        <Table.Cell>{event.name}</Table.Cell>
+                        <Table.Cell>{event.category}</Table.Cell>
+                        <Table.Cell>
+                          {moment(event.expiration)
+                            .local()
+                            .format("MM/DD/YYYY @ hh:mm A")}
+                        </Table.Cell>
+                        <Table.Cell>{event.semester}</Table.Cell>
+                        <Table.Cell textAlign="center">
+                          {event.request === true ? (
+                            <Icon className="request-true" name="check" />
+                          ) : (
+                            <Icon className="request-false" name="x" />
+                          )}
+                        </Table.Cell>
+                        <Table.Cell textAlign="center">
+                          {event.attendance}
+                        </Table.Cell>
+                        <Table.Cell textAlign="center">
+                          {event.points}
+                        </Table.Cell>
+                        <Table.Cell textAlign="center">
+                          <Button
+                            icon
+                            onClick={() => {
+                              setSelectedEvent(event.name);
+                              setManualInputModal(true);
+                            }}
+                          >
+                            <Icon name="i cursor" />
+                          </Button>
+                        </Table.Cell>
+                        <Table.Cell textAlign="center">
+                          <Button
+                            icon
+                            onClick={() => {
+                              setEventAttendance(event);
+                              setEventInfoModal(true);
+                            }}
+                          >
+                            <Icon name="info" />
+                          </Button>
+                        </Table.Cell>
+                        <Table.Cell textAlign="center">
+                          <Button
+                            icon
+                            onClick={() => {
+                              setSelectedEvent(event.name);
+                              setDeleteEventModal(true);
+                            }}
+                            color="red"
+                          >
+                            <Icon name="x" />
+                          </Button>
+                        </Table.Cell>
+                      </Table.Row>
+                    ))}
+                </Table.Body>
+              </Table>
+            </Grid.Row>
+            <Grid.Row>
+              <CSVLink data={eventsNoUsers} filename={"events.csv"}>
+                <Button color="green" floated="right">
+                  Download as CSV
+                </Button>
+              </CSVLink>
+            </Grid.Row>
+          </Grid>
         </div>
       )}
 

--- a/src/pages/Events.js
+++ b/src/pages/Events.js
@@ -1,11 +1,19 @@
 import React, { useState } from "react";
-import { Grid, Button, Form, Modal, Container } from "semantic-ui-react";
+import {
+  Grid,
+  Button,
+  Form,
+  Modal,
+  Container,
+  Dimmer,
+  Loader,
+} from "semantic-ui-react";
 import gql from "graphql-tag";
 import { useQuery, useMutation } from "@apollo/react-hooks";
 import { useForm } from "../util/hooks";
 
 import Title from "../components/Title";
-import EventsTable from "../components/EventsTable";
+import EventsAccordion from "../components/EventsAccordion";
 
 import { FETCH_EVENTS_QUERY } from "../util/graphql";
 
@@ -20,13 +28,13 @@ function Events() {
     events = data.getEvents;
   }
 
-  const openModal = name => {
+  const openModal = (name) => {
     if (name === "createEvent") {
       setCreateEventModal(true);
     }
   };
 
-  const closeModal = name => {
+  const closeModal = (name) => {
     if (name === "createEvent") {
       values.name = "";
       values.code = "";
@@ -47,16 +55,11 @@ function Events() {
     category: "",
     expiration: "",
     points: "",
-    request: "false"
+    request: "false",
   });
 
   const [createEvent, { loading }] = useMutation(CREATE_EVENT_MUTATION, {
-    update(
-      _,
-      {
-        data: { createEvent: eventsData }
-      }
-    ) {
+    update(_, { data: { createEvent: eventsData } }) {
       values.name = "";
       values.code = "";
       values.category = "";
@@ -75,7 +78,7 @@ function Events() {
       setErrors(err.graphQLErrors[0].extensions.exception.errors);
     },
 
-    variables: values
+    variables: values,
   });
 
   function createEventCallback() {
@@ -100,7 +103,10 @@ function Events() {
           </Grid.Row>
           <Grid.Row>
             <Grid.Column>
-              <EventsTable events={events} />
+              <Dimmer active={events ? false : true} inverted>
+                <Loader />
+              </Dimmer>
+              <EventsAccordion events={events} />
             </Grid.Column>
           </Grid.Row>
         </Grid>
@@ -122,7 +128,7 @@ function Events() {
                 {Object.keys(errors).length > 0 && (
                   <div className="ui error message">
                     <ul className="list">
-                      {Object.values(errors).map(value => (
+                      {Object.values(errors).map((value) => (
                         <li key={value}>{value}</li>
                       ))}
                     </ul>
@@ -157,7 +163,7 @@ function Events() {
                     error={errors.category ? true : false}
                     onChange={onChange}
                   >
-                    {categoryOptions.map(category =>
+                    {categoryOptions.map((category) =>
                       category.points === 0 ? (
                         <option value={category.value} key={category.key}>
                           {category.value}
@@ -193,7 +199,7 @@ function Events() {
                     error={errors.expiration ? true : false}
                     onChange={onChange}
                   >
-                    {expirationOptions.map(expiration => (
+                    {expirationOptions.map((expiration) => (
                       <option value={expiration.value} key={expiration.key}>
                         {expiration.key}
                       </option>


### PR DESCRIPTION
### Summary

the event table in admin panel is now organized by semester rather than having all the semesters in one big list.

Reference

[Asana link](https://app.asana.com/0/1202843173947642/1204034964186883/f)

![](https://user-images.githubusercontent.com/59676526/220459965-e2dfe158-5b00-43ec-9200-64d2bce60e7b.png)

^^ current events table (disorganized and ugly)

![](https://user-images.githubusercontent.com/59676526/220459979-d7950aa8-36e0-46ab-92ee-f9bde71c02c4.png)

^^ new and updated events table organized and beautiful

![](https://user-images.githubusercontent.com/59676526/220459988-2efea36b-1572-40b1-bcfa-aa2ba4856241.png)

^^ download as csv btn that actually works

