### PR TITLE
changed google calendar api call to only get events from 1yr ago

### DIFF
--- a/src/pages/public/MyCalendar.js
+++ b/src/pages/public/MyCalendar.js
@@ -22,7 +22,9 @@ function MyCalendar() {
     }
  
     function getAllEvents(){
-        fetch('https://www.googleapis.com/calendar/v3/calendars/'+calendarId+'/events?key='+API_KEY)
+        const oneYearAgo = new Date();
+        oneYearAgo.setFullYear(oneYearAgo.getFullYear() - 1);
+        fetch('https://www.googleapis.com/calendar/v3/calendars/'+calendarId+'/events?timeMin='+oneYearAgo.toISOString()+'&key='+REACT_APP_API_KEY)
             .then(response => response.json())
             .then(data => setEvents(data.items));
     }

--- a/src/pages/public/MyCalendar.js
+++ b/src/pages/public/MyCalendar.js
@@ -24,7 +24,7 @@ function MyCalendar() {
     function getAllEvents(){
         const oneYearAgo = new Date();
         oneYearAgo.setFullYear(oneYearAgo.getFullYear() - 1);
-        fetch('https://www.googleapis.com/calendar/v3/calendars/'+calendarId+'/events?timeMin='+oneYearAgo.toISOString()+'&key='+REACT_APP_API_KEY)
+        fetch('https://www.googleapis.com/calendar/v3/calendars/'+calendarId+'/events?timeMin='+oneYearAgo.toISOString()+'&key='+API_KEY)
             .then(response => response.json())
             .then(data => setEvents(data.items));
     }


### PR DESCRIPTION
### Summary

The google calendar API defaults to only return a maximum of 250 events. This was keeping shpeuf.com/calendar  from displaying current events. Now, the API call only polls for events started 1yr ago from the current date.

### Extra

_please add me (@w-omar) as a reviewer. thank u_
