### PR TITLE
updated reading url parameters and fixed spamming the CONFIRM_USER mutation

### DIFF
--- a/src/pages/public/Confirm.js
+++ b/src/pages/public/Confirm.js
@@ -1,26 +1,29 @@
-import React, { useState, useEffect } from "react";
+import React, { useCallback, useState, useEffect } from "react";
 import gql from "graphql-tag";
 import { useMutation } from "@apollo/client";
 import { Segment, Dimmer, Loader, Container, Grid } from "semantic-ui-react";
 import { Media } from "../../Media";
+import { useParams } from 'react-router-dom';
 
-function Confirm(props){
+function Confirm(){
   const [confirming, setConfirming] = useState(false);
+  
+  const value = useParams();
 
-  const value  = {
-    id: props.match.params.id
-  };
+  const [confirmMutation] = useMutation(CONFIRM_USER);
 
-  const [confirm] = useMutation(CONFIRM_USER, {
-    onCompleted(){
-      setConfirming(false);
-    },
-    variables: value
-  });
+  const confirm = useCallback(() => {
+    confirmMutation({
+      variables: value,
+      onCompleted: () => {
+        setConfirming(false);
+      }
+    })
+  }, [confirmMutation, value]);
 
   useEffect(() => {
     confirm();
-  });
+  }, [confirm]);
 
   return(
 


### PR DESCRIPTION
### Summary

react-router-v6 changed the syntax for reading parameters from the url. I implemented this change for confirming users. Additionally, the CONFIRM_USER mutation was being spammed by the client. I added the useCallBack hook to invoke the mutation to fix this.

### Reference

_Reference your Asana task here as shown below_

N/A

### Extra

_please add me (@w-omar) as a reviewer. thank u_
