### PR TITLE
Removevisualuser

### DIFF
--- a/src/components/Events/EventsTable.js
+++ b/src/components/Events/EventsTable.js
@@ -31,6 +31,14 @@ function EventsTable({ events }) {
 
   const [removeUserFromEvent] = useMutation(REMOVE_USER_MUTATION, {
     update(cache, { data: { removeUserFromEvent } }) {
+      setEventAttendance((prevEventAttendance)=> {
+        const updatedUsers = removeUserFromEvent.users;
+        return {
+          ...prevEventAttendance,
+          users: updatedUsers,
+          attendance: updatedUsers.length,
+        };
+      });
       const { getEvents } = cache.readQuery({ query: FETCH_EVENTS_QUERY });
 
       getEvents.forEach((event, pos) => {

--- a/src/components/ManualInputModal.js
+++ b/src/components/ManualInputModal.js
@@ -125,19 +125,21 @@ const MANUAL_INPUT_MUTATION = gql`
     manualInput(
       manualInputInput: { username: $username, eventName: $eventName }
     ) {
+      id
       name
       code
       category
       expiration
-      semester
       request
-      attendance
       points
+      attendance
+      semester
+      createdAt
       users {
+        email
+        username
         firstName
         lastName
-        username
-        email
       }
     }
   }


### PR DESCRIPTION
### Summary
Under Events Table: created const updatedUsers to reference the users that remain after a remove user mutation. In the return statement that follows, overwrite the prevEventAttendance users to match which users went to the event and the attendance after removing the user.

### Reference
[Asana link](https://app.asana.com/0/1202843173947642/1206376368913031/f) 
