### PR TITLE
Use navigate

### DIFF
--- a/src/components/Events/EventsTable.js
+++ b/src/components/Events/EventsTable.js
@@ -31,6 +31,14 @@ function EventsTable({ events }) {
 
   const [removeUserFromEvent] = useMutation(REMOVE_USER_MUTATION, {
     update(cache, { data: { removeUserFromEvent } }) {
+      setEventAttendance((prevEventAttendance)=> {
+        const updatedUsers = removeUserFromEvent.users;
+        return {
+          ...prevEventAttendance,
+          users: updatedUsers,
+          attendance: updatedUsers.length,
+        };
+      });
       const { getEvents } = cache.readQuery({ query: FETCH_EVENTS_QUERY });
 
       getEvents.forEach((event, pos) => {

--- a/src/components/ManualInputModal.js
+++ b/src/components/ManualInputModal.js
@@ -125,19 +125,21 @@ const MANUAL_INPUT_MUTATION = gql`
     manualInput(
       manualInputInput: { username: $username, eventName: $eventName }
     ) {
+      id
       name
       code
       category
       expiration
-      semester
       request
-      attendance
       points
+      attendance
+      semester
+      createdAt
       users {
+        email
+        username
         firstName
         lastName
-        username
-        email
       }
     }
   }

--- a/src/pages/public/Login.js
+++ b/src/pages/public/Login.js
@@ -12,9 +12,11 @@ import gql from "graphql-tag";
 
 import { AuthContext } from "../../context/auth";
 import { useForm } from "../../util/hooks";
-import { NavLink } from "react-router-dom";
+import { NavLink, useNavigate } from "react-router-dom";
 
 function Login(props) {
+  const history = useNavigate();
+
   const context = useContext(AuthContext);
   const [errors, setErrors] = useState({});
 
@@ -27,7 +29,7 @@ function Login(props) {
   const [loginUser, { loading }] = useMutation(LOGIN_USER, {
     update(_, { data: { login: userData } }) {
       context.login(userData);
-      props.history.push("/points");
+      history("/points");
       window.location.reload();
     },
 

--- a/src/pages/public/Register.js
+++ b/src/pages/public/Register.js
@@ -14,6 +14,8 @@ import gql from "graphql-tag";
 
 import { useForm } from "../../util/hooks";
 
+import { useNavigate } from "react-router-dom";
+
 import majorOptions from "../../assets/options/major.json";
 import yearOptions from "../../assets/options/year.json";
 import graduatingOptions from "../../assets/options/graduating.json";
@@ -22,12 +24,14 @@ import ethnicityOptions from "../../assets/options/ethnicity.json";
 import sexOptions from "../../assets/options/sex.json";
 
 function Register(props) {
+  const history = useNavigate();
+
   const [errors, setErrors] = useState({});
   const [openModal, setOpenModal] = useState(false);
 
   const handleClose = () => {
     setOpenModal(false);
-    props.history.push("/login");
+    history("/login");
   };
 
   const { onChange, onSubmit, values } = useForm(registerUser, {

--- a/src/pages/public/ResetPassword.js
+++ b/src/pages/public/ResetPassword.js
@@ -3,11 +3,12 @@ import { Form, Button, Container, Segment, Grid } from "semantic-ui-react";
 import { Media } from "../../Media";
 import gql from "graphql-tag";
 import { useMutation } from "@apollo/client";
-
+import { useNavigate } from "react-router-dom";
 import { useForm } from "../../util/hooks";
 
 function ResetPassword(props){
-
+  const history = useNavigate();
+  
   const [errors, setErrors] = useState({});
 
   const { onChange, onSubmit, values } = useForm(callback, {
@@ -22,7 +23,7 @@ function ResetPassword(props){
       setErrors(err.graphQLErrors[0].extensions.exception.errors);
     },
     onCompleted(){
-      props.history.push("/login");
+      history("/login");
     },
     variables: values
   });


### PR DESCRIPTION
### Summary

The client was using a deprecated method of redirecting after registering, logging in, and resetting pwd. This has been replaced with the up to date useNavigate hook. Users will now correctly be routed to the points page after logging in.

### Reference

N/A

### Extra

_please add me (@w-omar) as a reviewer. thank u_
