### PR TITLE
Fixed reading URL parameters for pswd reset

### DIFF
--- a/src/pages/public/ResetPassword.js
+++ b/src/pages/public/ResetPassword.js
@@ -3,6 +3,7 @@ import { Form, Button, Container, Segment, Grid } from "semantic-ui-react";
 import { Media } from "../../Media";
 import gql from "graphql-tag";
 import { useMutation } from "@apollo/client";
+import { useParams } from 'react-router-dom';
 
 import { useForm } from "../../util/hooks";
 
@@ -10,10 +11,12 @@ function ResetPassword(props){
 
   const [errors, setErrors] = useState({});
 
+  const value = useParams();
+
   const { onChange, onSubmit, values } = useForm(callback, {
     password: "",
     confirmPassword: "",
-    token: props.match.params.token
+    token: value.token
   });
 
 


### PR DESCRIPTION
### Summary

Fixed reading URL parameters for password resetting by using the `useParams()` hook. Now the Reset Password pages loads and functions properly. Checked functionality by updating my password.

### Reference

_Reference your Asana task here as shown below_

[Asana link]https://app.asana.com/0/1202843173947642/1206376246890697/f

### Extra

_please add me (@w-omar) as a reviewer. thank u_


![Fixed reading URL for password resetting](https://github.com/shpe-uf/SHPE-UF-CLIENT/assets/116681521/6544b757-01b7-4088-8da6-97be7684219f)
