### PR TITLE
Fetch events rename

### DIFF
--- a/src/components/ManualInputModal.js
+++ b/src/components/ManualInputModal.js
@@ -6,7 +6,7 @@ import gql from 'graphql-tag';
 
 function ManualInputModal(props) {
   const [errors, setErrors] = useState({});
-  const [user, setUser] = useState('');
+  const [userArray, setUser] = useState([]);
 
   let users = null;
   let {data} = useQuery(FETCH_USERS_QUERY);
@@ -61,6 +61,13 @@ function ManualInputModal(props) {
     }
   });
 
+  const onSubmit = () => {
+    userArray.forEach(user => {
+      props.type === 'event' && manualInput({variables: {username: user, eventName: props.addObject}})
+      props.type === 'task' && manualTaskInput({variables: {username: user, taskName: props.addObject}})
+    })
+  } 
+  
   return (
     <Modal
       open={props.open}
@@ -90,6 +97,7 @@ function ManualInputModal(props) {
                 fluid
                 search
                 selection
+                multiple 
                 onChange={(_,data) => setUser(data.value)}
               />
               <Divider hidden/>
@@ -106,10 +114,8 @@ function ManualInputModal(props) {
               <Button
                 type="submit"
                 floated="right"
-                onClick={() => {
-                  props.type === 'event' && manualInput({variables: {username: user, eventName: props.addObject}})
-                  props.type === 'task' && manualTaskInput({variables: {username: user, taskName: props.addObject}})
-                }}>
+                onClick={onSubmit}
+                >
                 Submit
               </Button>
             </Grid.Column>

--- a/src/pages/Events.js
+++ b/src/pages/Events.js
@@ -15,7 +15,7 @@ import { useForm } from "../util/hooks";
 import Title from "../components/Title";
 import EventsAccordion from "../components/Events/EventsAccordion";
 
-import { FETCH_EVENTS_REVERSED_QUERY } from "../util/graphql";
+import { FETCH_EVENTS_QUERY } from "../util/graphql";
 
 
 import categoryOptions from "../assets/options/category.json";
@@ -24,7 +24,7 @@ import expirationOptions from "../assets/options/expiration.json";
 function Events() {
   const [errors, setErrors] = useState({});
   let events = null;
-  let { data } = useQuery(FETCH_EVENTS_REVERSED_QUERY);
+  let { data } = useQuery(FETCH_EVENTS_QUERY);
   if (data) {
     events = data.getEventsReversed;
   }

--- a/src/util/graphql.js
+++ b/src/util/graphql.js
@@ -39,28 +39,6 @@ export const FETCH_USERS_QUERY = gql`
 
 export const FETCH_EVENTS_QUERY = gql`
   {
-    getEvents {
-      id
-      name
-      code
-      category
-      points
-      request
-      attendance
-      expiration
-      semester
-      createdAt
-      users {
-        firstName
-        lastName
-        username
-        email
-      }
-    }
-  }
-`;
-export const FETCH_EVENTS_REVERSED_QUERY = gql`
-  {
     getEventsReversed {
       id
       name


### PR DESCRIPTION
### Summary

When completing a previous task related to manual input for attendance, console would throw an error even if attendance updated after a refresh. The event would be referencing a FETCH_EVENTS_REVERSED_QUERY which was essentially the same as FETCH_EVENTS_QUERY, so this change removed that reversed query everywhere it was mentioned and replaced it with regular fetch events query.

### Reference

_Reference your Asana task here as shown below_

[Asana link](https://app.asana.com/0/1202843173947642/1203349950677660/f)

