### PR TITLE
Permission String Discrepancies

### DIFF
--- a/src/components/PermissionsForm.js
+++ b/src/components/PermissionsForm.js
@@ -62,6 +62,12 @@ export default function PermissionsForm({userInfo, refetch}) {
             }
         }
 
+        // In this scenario, if a user is already a super admin, but is demoted to any other permission,
+        // then they lose their super admin role in favor of the diminished role.
+        if (name !== PERMISSIONS.SUPER && tempPermissions.includes(PERMISSIONS.SUPER)) {
+            tempPermissions = name;
+        }
+
         // In this scenario, if a user is simply a member and they are granted any other permission (an admin role), then they lose
         // their member permission in favor of the higher admin role. The inverse is true if a user is demoted to member only.
         if (name !== PERMISSIONS.MEMBER && tempPermissions.includes(PERMISSIONS.MEMBER)) {
@@ -102,7 +108,6 @@ export default function PermissionsForm({userInfo, refetch}) {
             permission: permissions
         }
         setOriginalPermissions(permissions.split("-"));
-        console.log(values);
         changePermissionMutation({variables: values})
     }
 
@@ -119,8 +124,7 @@ export default function PermissionsForm({userInfo, refetch}) {
                         <Form.Group>
                             <Form.Radio
                                 toggle
-                                disabled={!loggedInUser.permission.includes(PERMISSIONS.SUPER)
-                                    || permissions.includes(PERMISSIONS.SUPER)}
+                                disabled={!loggedInUser.permission.includes(PERMISSIONS.SUPER)}
                                 name={PERMISSIONS.TASKS}
                                 checked={permissions.includes(PERMISSIONS.TASKS)
                                     && !permissions.includes(PERMISSIONS.SUPER)}
@@ -129,8 +133,7 @@ export default function PermissionsForm({userInfo, refetch}) {
                             />
                             <Form.Radio
                                 toggle
-                                disabled={!loggedInUser.permission.includes(PERMISSIONS.SUPER)
-                                    || permissions.includes(PERMISSIONS.SUPER)}
+                                disabled={!loggedInUser.permission.includes(PERMISSIONS.SUPER)}
                                 name={PERMISSIONS.REQUESTS}
                                 checked={permissions.includes(PERMISSIONS.REQUESTS)
                                     && !permissions.includes(PERMISSIONS.SUPER)}
@@ -141,8 +144,7 @@ export default function PermissionsForm({userInfo, refetch}) {
                         <Form.Group>
                             <Form.Radio
                                 toggle
-                                disabled={!loggedInUser.permission.includes(PERMISSIONS.SUPER)
-                                    || permissions.includes(PERMISSIONS.SUPER)}
+                                disabled={!loggedInUser.permission.includes(PERMISSIONS.SUPER)}
                                 name={PERMISSIONS.EVENTS}
                                 checked={permissions.includes(PERMISSIONS.EVENTS)
                                     && !permissions.includes(PERMISSIONS.SUPER)}
@@ -161,8 +163,7 @@ export default function PermissionsForm({userInfo, refetch}) {
                         <Form.Group>
                             <Form.Radio
                                 toggle
-                                disabled={!loggedInUser.permission.includes(PERMISSIONS.SUPER)
-                                    || permissions.includes(PERMISSIONS.SUPER)}
+                                disabled={!loggedInUser.permission.includes(PERMISSIONS.SUPER)}
                                 name={PERMISSIONS.STATS}
                                 checked={permissions.includes(PERMISSIONS.STATS)
                                     && !permissions.includes(PERMISSIONS.SUPER)}
@@ -171,8 +172,7 @@ export default function PermissionsForm({userInfo, refetch}) {
                             />
                             <Form.Radio
                                 toggle
-                                disabled={!loggedInUser.permission.includes(PERMISSIONS.SUPER)
-                                    || permissions.includes(PERMISSIONS.SUPER)}
+                                disabled={!loggedInUser.permission.includes(PERMISSIONS.SUPER)}
                                 name={PERMISSIONS.REIMB}
                                 checked={permissions.includes(PERMISSIONS.REIMB)
                                     && !permissions.includes(PERMISSIONS.SUPER)}
@@ -183,8 +183,7 @@ export default function PermissionsForm({userInfo, refetch}) {
                         <Form.Group>
                             <Form.Radio
                                 toggle
-                                disabled={!loggedInUser.permission.includes(PERMISSIONS.SUPER)
-                                    || permissions.includes(PERMISSIONS.SUPER)}
+                                disabled={!loggedInUser.permission.includes(PERMISSIONS.SUPER)}
                                 name={PERMISSIONS.MEMBER}
                                 checked={permissions.includes(PERMISSIONS.MEMBER)
                                     && !permissions.includes(PERMISSIONS.SUPER)}
@@ -193,8 +192,7 @@ export default function PermissionsForm({userInfo, refetch}) {
                             />
                             <Form.Radio
                                 toggle
-                                disabled={!loggedInUser.permission.includes(PERMISSIONS.SUPER)
-                                    || permissions.includes(PERMISSIONS.SUPER)}
+                                disabled={!loggedInUser.permission.includes(PERMISSIONS.SUPER)}
                                 name={PERMISSIONS.CORP}
                                 checked={permissions.includes(PERMISSIONS.CORP)
                                     && !permissions.includes(PERMISSIONS.SUPER)}

--- a/src/components/PermissionsForm.js
+++ b/src/components/PermissionsForm.js
@@ -55,7 +55,7 @@ export default function PermissionsForm({userInfo, refetch}) {
             }
         } else {
             if (name === PERMISSIONS.SUPER) {
-                tempPermissions = userInfo.permission;
+                tempPermissions = userInfo.permission.includes(PERMISSIONS.SUPER) ? '' : userInfo.permission;
             } else {
                 tempPermissions = permissions.replaceAll(re1, '-')
                 tempPermissions = permissions.replaceAll(re2, '')

--- a/src/components/PermissionsForm.js
+++ b/src/components/PermissionsForm.js
@@ -43,20 +43,37 @@ export default function PermissionsForm({userInfo, refetch}) {
     const onChange = (_, {name, checked}) => {
         //regex used to remove a permissions from the string formatted as "permission-permission-permission"
         //accounts for the three possible ways in which a permission is found, namely at the beginning, inside, or the end
-        // let re = new RegExp(`/(-${name}-)|(${name}-)|(-${name})/`)
-        let re = new RegExp(`(-${name}-)|(${name}-)|(-${name})|(${name})`, 'g')
+        let re1 = new RegExp(`(-${name}-)`, 'g')
+        let re2 = new RegExp(`(${name}-)|(-${name})|(${name})`, 'g')
         let tempPermissions = ''
 
         if (checked){
-            tempPermissions = permissions.concat( (permissions.length !== 0) ? `-${name}` : `${name}`)
+            if (name === PERMISSIONS.SUPER) {
+                tempPermissions = PERMISSIONS.SUPER;
+            } else {
+                tempPermissions = permissions.concat( (permissions.length !== 0) ? `-${name}` : `${name}`)
+            }
         } else {
-            tempPermissions = permissions.replaceAll(re, '')
+            if (name === PERMISSIONS.SUPER) {
+                tempPermissions = userInfo.permission;
+            } else {
+                tempPermissions = permissions.replaceAll(re1, '-')
+                tempPermissions = permissions.replaceAll(re2, '')
+            }
+        }
+
+        // In this scenario, if a user is simply a member and they are granted any other permission (an admin role), then they lose
+        // their member permission in favor of the higher admin role. The inverse is true if a user is demoted to member only.
+        if (name !== PERMISSIONS.MEMBER && tempPermissions.includes(PERMISSIONS.MEMBER)) {
+            tempPermissions = name;
+        } else if (name === PERMISSIONS.MEMBER) {
+            tempPermissions = PERMISSIONS.MEMBER;
         }
 
         // In this scenario, this is a regular use that has been granted a permission for the first time (that is not super).
         // We automatically make that user an admin, granted that the user already contains at least one permission
-        if (!tempPermissions.includes(PERMISSIONS.ADMIN) && tempPermissions.length > 0) {
-            tempPermissions = permission.concat(PERMISSIONS.ADMIN)
+        if (!tempPermissions.includes(PERMISSIONS.ADMIN) && tempPermissions.length > 0 && name !== PERMISSIONS.MEMBER) {
+            tempPermissions = PERMISSIONS.ADMIN.concat("-" + tempPermissions);
         }
 
         // In this scenario, the user has been stripped of all permissions, and only admin is left.
@@ -84,6 +101,8 @@ export default function PermissionsForm({userInfo, refetch}) {
             currentEmail: loggedInUser.email,
             permission: permissions
         }
+        setOriginalPermissions(permissions.split("-"));
+        console.log(values);
         changePermissionMutation({variables: values})
     }
 
@@ -100,17 +119,21 @@ export default function PermissionsForm({userInfo, refetch}) {
                         <Form.Group>
                             <Form.Radio
                                 toggle
-                                disabled={!loggedInUser.permission.includes(PERMISSIONS.SUPER)}
+                                disabled={!loggedInUser.permission.includes(PERMISSIONS.SUPER)
+                                    || permissions.includes(PERMISSIONS.SUPER)}
                                 name={PERMISSIONS.TASKS}
-                                defaultChecked={userInfo.permission.includes(PERMISSIONS.TASKS)}
+                                checked={permissions.includes(PERMISSIONS.TASKS)
+                                    && !permissions.includes(PERMISSIONS.SUPER)}
                                 onChange={onChange}
                                 label='Tasks'
                             />
                             <Form.Radio
                                 toggle
-                                disabled={!loggedInUser.permission.includes(PERMISSIONS.SUPER)}
+                                disabled={!loggedInUser.permission.includes(PERMISSIONS.SUPER)
+                                    || permissions.includes(PERMISSIONS.SUPER)}
                                 name={PERMISSIONS.REQUESTS}
-                                defaultChecked={userInfo.permission.includes(PERMISSIONS.REQUESTS)}
+                                checked={permissions.includes(PERMISSIONS.REQUESTS)
+                                    && !permissions.includes(PERMISSIONS.SUPER)}
                                 onChange={onChange}
                                 label='Requests'
                             />
@@ -118,9 +141,11 @@ export default function PermissionsForm({userInfo, refetch}) {
                         <Form.Group>
                             <Form.Radio
                                 toggle
-                                disabled={!loggedInUser.permission.includes(PERMISSIONS.SUPER)}
+                                disabled={!loggedInUser.permission.includes(PERMISSIONS.SUPER)
+                                    || permissions.includes(PERMISSIONS.SUPER)}
                                 name={PERMISSIONS.EVENTS}
-                                defaultChecked={userInfo.permission.includes(PERMISSIONS.TASKS)}
+                                checked={permissions.includes(PERMISSIONS.EVENTS)
+                                    && !permissions.includes(PERMISSIONS.SUPER)}
                                 onChange={onChange}
                                 label='Events'
                             />
@@ -128,7 +153,7 @@ export default function PermissionsForm({userInfo, refetch}) {
                                 toggle
                                 disabled={!loggedInUser.permission.includes(PERMISSIONS.SUPER)}
                                 name={PERMISSIONS.SUPER}
-                                defaultChecked={userInfo.permission.includes(PERMISSIONS.SUPER)}
+                                checked={permissions.includes(PERMISSIONS.SUPER)}
                                 onChange={onChange}
                                 label='Super Admin'
                             />
@@ -136,17 +161,21 @@ export default function PermissionsForm({userInfo, refetch}) {
                         <Form.Group>
                             <Form.Radio
                                 toggle
-                                disabled={!loggedInUser.permission.includes(PERMISSIONS.SUPER)}
+                                disabled={!loggedInUser.permission.includes(PERMISSIONS.SUPER)
+                                    || permissions.includes(PERMISSIONS.SUPER)}
                                 name={PERMISSIONS.STATS}
-                                defaultChecked={userInfo.permission.includes(PERMISSIONS.STATS)}
+                                checked={permissions.includes(PERMISSIONS.STATS)
+                                    && !permissions.includes(PERMISSIONS.SUPER)}
                                 onChange={onChange}
                                 label='Statistics'
                             />
                             <Form.Radio
                                 toggle
-                                disabled={!loggedInUser.permission.includes(PERMISSIONS.SUPER)}
+                                disabled={!loggedInUser.permission.includes(PERMISSIONS.SUPER)
+                                    || permissions.includes(PERMISSIONS.SUPER)}
                                 name={PERMISSIONS.REIMB}
-                                defaultChecked={userInfo.permission.includes(PERMISSIONS.REIMB)}
+                                checked={permissions.includes(PERMISSIONS.REIMB)
+                                    && !permissions.includes(PERMISSIONS.SUPER)}
                                 onChange={onChange}
                                 label='Reimbursements'
                             />
@@ -154,17 +183,21 @@ export default function PermissionsForm({userInfo, refetch}) {
                         <Form.Group>
                             <Form.Radio
                                 toggle
-                                disabled={!loggedInUser.permission.includes(PERMISSIONS.SUPER)}
-                                name={PERMISSIONS.MEMBERS}
-                                defaultChecked={userInfo.permission.includes(PERMISSIONS.MEMBERS)}
+                                disabled={!loggedInUser.permission.includes(PERMISSIONS.SUPER)
+                                    || permissions.includes(PERMISSIONS.SUPER)}
+                                name={PERMISSIONS.MEMBER}
+                                checked={permissions.includes(PERMISSIONS.MEMBER)
+                                    && !permissions.includes(PERMISSIONS.SUPER)}
                                 onChange={onChange}
-                                label='Members'
+                                label='Member'
                             />
                             <Form.Radio
                                 toggle
-                                disabled={!loggedInUser.permission.includes(PERMISSIONS.SUPER)}
+                                disabled={!loggedInUser.permission.includes(PERMISSIONS.SUPER)
+                                    || permissions.includes(PERMISSIONS.SUPER)}
                                 name={PERMISSIONS.CORP}
-                                defaultChecked={userInfo.permission.includes(PERMISSIONS.CORP)}
+                                checked={permissions.includes(PERMISSIONS.CORP)
+                                    && !permissions.includes(PERMISSIONS.SUPER)}
                                 onChange={onChange}
                                 label='Corporate Database'
                             />

--- a/src/util/permissions.js
+++ b/src/util/permissions.js
@@ -1,7 +1,7 @@
 export const PERMISSIONS = {
     ADMIN: 'admin',
     SUPER: 'admin-super',
-    MEMBERS: 'members',
+    MEMBER: 'member',
     EVENTS: 'events',
     TASKS: 'tasks',
     REQUESTS: 'requests',


### PR DESCRIPTION
### Summary

Addressed permission string discrepancies by adding a few new changes:

* If a user does not have any extra privileges, then they will simply have the "member" tag
  - If the user is promoted, they lose their "member" tag in favor of the "admin-${new_role}" tag
* If a user is granted the super admin role, all other role tags are dropped in favor of the "admin-super" tag
* It is now impossible to assign contradicting roles to a user via toggles:
  - Switching on a toggle will toggle-off the contradicting toggles.
* Regex is now corrected to account for a permission removal edge case.

Tested using Daniels Testing Account:
ID: 65ba91292087b54a5627e820
email: woopdewoop@ufl.edu

### Reference

_Reference your Asana task here as shown below_

[Asana link](https://app.asana.com/0/1202843173947642/1205571123247082/f)

### Extra

_please add me (@w-omar) as a reviewer. thank u_
