### PR TITLE
Changed close button to be just grey close icon at top right of modal

### DIFF
--- a/src/components/JrEventModal.js
+++ b/src/components/JrEventModal.js
@@ -22,7 +22,7 @@ function JrEventModal(event, description, pic) {
         </Grid>
       }
     >
-      <Modal.Header>{event}</Modal.Header>
+      <Modal.Header>{event} <Button icon="close" color="grey" onClick={() => setOpen(false)}></Button></Modal.Header>
       <Modal.Content image>
         <Grid>
           <Grid.Column width={5}>
@@ -35,13 +35,6 @@ function JrEventModal(event, description, pic) {
         </Grid>
       </Modal.Content>
       <Modal.Actions>
-        <Button
-          content="Close"
-          labelPosition="right"
-          icon="checkmark"
-          onClick={() => setOpen(false)}
-          positive
-        />
       </Modal.Actions>
     </Modal>
   );

--- a/src/components/JrSchoolModal.js
+++ b/src/components/JrSchoolModal.js
@@ -21,7 +21,7 @@ function JrSchoolModal(schoolName, description, pic){
                 </Grid>
               }
         >
-        <Modal.Header>{schoolName}</Modal.Header>
+        <Modal.Header>{schoolName} <Button icon="close" color="grey" onClick={() => setOpen(false)} /></Modal.Header>
         <Modal.Content image>
             <Grid>
                 <Grid.Column width = {5}>
@@ -33,16 +33,6 @@ function JrSchoolModal(schoolName, description, pic){
                 </Grid.Column>
             </Grid>
         </Modal.Content>
-        <Modal.Actions>
-            <Button
-                content = "Close"
-                labelPosition="right"
-                icon = "checkmark"
-                onClick={()=> setOpen(false)}
-                positive
-            />
-        </Modal.Actions>
-
         </Modal>
 
     );

--- a/src/components/SJrHighEvent.js
+++ b/src/components/SJrHighEvent.js
@@ -68,7 +68,7 @@ const event4 = (
 
 const event5 = (
   <div>
-    This event consists of  virtual sessions designed to provide high school students with 
+    This event consists of virtual sessions designed to provide high school students with 
     valuable information on pursuing an academic career in STEM and how to prepare for college. 
     Students will get the chance to learn about the college admission process and will receive 
     guidance on academic success and career development in STEM.


### PR DESCRIPTION
### Summary

For shpe jr event modals, they used to have a green, 'positive' styled close button with a checkmark icon. This had to be changed to a grey close button at the top right instead. I used the simple close button style from the cabinet modals - this can be modified to include the word "Close" right next to the X icon if wanted. 

For sake of shpe jr, this task was submitted, however, an additional task was made to address 'close' button inconsistency across the site :)

### Reference

_Reference your Asana task here as shown below_

[Asana link](https://app.asana.com/0/1202843173947642/1207106441267533/f)

