### PR TITLE
Revert "New Inputs for Creating an Event"

### DIFF
--- a/src/pages/Events.js
+++ b/src/pages/Events.js
@@ -155,14 +155,6 @@ function Events() {
                   />
                   <Form.Input
                     type="text"
-                    label="Length of The Event"
-                    name="event length"
-                    value={values.length}
-                    error={errors.length ? true : false}
-                    onChange={onChange}
-                  />
-                  <Form.Input
-                    type="text"
                     label="Code"
                     name="code"
                     value={values.code}
@@ -198,14 +190,6 @@ function Events() {
                       error={errors.points ? true : false}
                       onChange={onChange}
                     />
-                  <Form.Input
-                    type="text"
-                    label="Hour-to-Shpoint Ratio"
-                    name="ratio"
-                    value={values.ratio}
-                    error={errors.ratio ? true : false}
-                    onChange={onChange}
-                  />
                   <Form.Field
                     control="select"
                     label="Expires in"


### PR DESCRIPTION
Reverts shpe-uf/SHPE-UF-CLIENT#252

There should be a dropdown for what the length of the event should be (1-10) and put hours after the length of the event. This is to prevent human error.

It should only show the hour-to-shpoint ratio and the length of the event when Volunteering is selected as the category.

Length of the event and hour-to-shpoint ratio should be put at the bottom of the popup because it only becomes viewable once Volunteering is selected.