### PR TITLE
Added a Cancel button to close the corporation profile edit form

### DIFF
--- a/src/components/CorporationProfileForm.js
+++ b/src/components/CorporationProfileForm.js
@@ -360,9 +360,18 @@ function CorporationProfileForm({ corporation, closeModal, refetch }) {
           error={errors.signUpLink ? true : false}
           onChange={onChange}
         />
+        <div style={{ display: "flex", justifyContent: "space-between", marginTop: 16 }}>
+        <Button
+          type="reset"
+          color="red"
+          onClick={() => closeModal("editCorporation")}
+        >
+          Cancel
+        </Button>
         <Button type="submit" primary>
           Submit
         </Button>
+      </div>
       </Form>
     </>
   );


### PR DESCRIPTION
### Summary

Added close modal functionality to the <localhost>admin/corporatedatabse page. More specifically, created a "Cancel" button in the color red to close the edit corporation profile form -- the form that pops up when one clicks "View/Edit" and then "Edit Company". Before adding this button, one would need to refresh the page or submit an edit to the profile to exit out of the form. 

### Reference

_Reference your Asana task here as shown below_

[Asana link](https://app.asana.com/0/1202843173947642/1209360460129954/f)

### Extra

_please add me (@mxqrz) as a reviewer. thank you!
