### PR TITLE
Datadog monitoring

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { Navigate, BrowserRouter as Router, Route, Routes} from "react-router-dom";
+import { Navigate, BrowserRouter as Router, Route, Routes } from "react-router-dom";
 import { MediaContextProvider } from "./Media"
 
 import "semantic-ui-css/semantic.min.css";
@@ -51,6 +51,7 @@ import { jwtDecode } from "jwt-decode";
 import gql from "graphql-tag";
 import { useQuery } from "@apollo/client";
 import AdminResources from "./pages/AdminResources";
+import { datadogRum } from '@datadog/browser-rum';
 
 function App() {
   var decodedToken = [];
@@ -67,188 +68,202 @@ function App() {
 
   var permission = "";
 
-  if(localStorage.getItem("permission")) {
+  if (localStorage.getItem("permission")) {
     permission = localStorage.getItem("permission");
   }
+
+  datadogRum.init({
+    applicationId: '302b02dd-bfe8-4974-9804-4311286b5e0d',
+    clientToken: 'pub5aff11dd85c33c2b2ed80e9cdf218eab',
+    // `site` refers to the Datadog site parameter of your organization
+    // see https://docs.datadoghq.com/getting_started/site/
+    site: 'us5.datadoghq.com',
+    service: 'shpe-uf-client-web',
+    // Specify a version number to identify the deployed version of your application in Datadog
+    // version: '1.0.0',
+    sessionSampleRate: 100,
+    sessionReplaySampleRate: 20,
+    defaultPrivacyLevel: 'mask-user-input',
+  });
 
   return (
     <Router>
       <AuthProvider>
-      <MediaContextProvider>  
-          <div style={{minHeight: "calc(100vh - 66px"}}>
-          <MenuBar permission={permission}/>
-          <Routes>
-            <Route exact path="/" element={<Home/>} />
-            <Route exact path="/login"
-              element={
-                <AuthRoute>
-                  <Login/>
-                </AuthRoute>}
-            />
-            <Route exact path="/register"
-              element={
-                <AuthRoute>
-                  <Register/>
-                </AuthRoute>}
-            />
-            <Route exact path="/register/alumni" element={<RegisterAlumni/>} />
-            <Route exact path="/about" element={<About/>} />
-            <Route exact path="/alumni" element={<Alumni/>} />
-            <Route exact path="/eboard" element={<EBoard/>} />
-            <Route exact path="/devteam" element={<DevTeam/>} />
-            <Route exact path="/shpejr" element={<ShpeJr/>} />
-            <Route exact path="/sponsors" element={<Sponsors/>} />
-            <Route exact path="/contactus" element={<ContactUs/>} />
-            <Route exact path="/calendar" element={<MyCalendar/>} />
-            <Route exact path="/resources" element={<Resources/>}/>
-            <Route exact path="/corporations"
-              element={
-                <UserRoute>
-                  <Corporations/>
-                </UserRoute>}
-            />
-            <Route exact path="/reset/:token" element={<ResetPassword/>} />
-            <Route exact path="/forgot" element={<ForgotPassword/>} />
-            <Route exact path="/confirm/:id" element={<Confirm/>} />
-            <Route exact
-              path="/profile"
-              element={
-                <UserRoute>
-                  <Profile/>
-                </UserRoute>}
-            />
-            <Route exact path="/points"
-              element={
-                <UserRoute>
-                  <Points/>
-                </UserRoute>}
-            />
-            <Route exact path="/alumnidirectory"
-              element={
-              <UserRoute>
-                <AlumniDirectory/>
-              </UserRoute>}
-            />
-            <Route exact path="/reimbursementrequest"
-              element={
-                <UserRoute
-                  element={<ReimbursementRequest/>} 
-                  user={decodedToken}
-                />}
-            />
-            <Route exact path="/shpeitonetwork"
-              element={
-                <UserRoute>
-                  <ShpeitoNetwork/>
-                </UserRoute>}
-            />
-            <Route exact path="/mentorshpe"
-              element={
-              <UserRoute>
-                <MentorSHPE/>
-              </UserRoute>}
-            />
-            <Route exact path="/shperentals"
-              element={
-                <UserRoute>
-                  <ShpeRentals/>
-                </UserRoute>}
-            />
-            <Route exact path="/admin"
-              element={
-                <AdminRoute security="admin" permission={permission}>
-                  <Admin permission={permission}/>
-                </AdminRoute>}
-            />
-            <Route exact path="/admin/events" 
-              element={
-                <AdminRoute
-                  permission={permission}
-                  security="events">
-                    <Events/>
-                </AdminRoute>}
-            />
-            <Route exact path="/admin/tasks"
-              element={
-                <AdminRoute
-                  permission={permission}
-                  security="tasks"
-                >
-                  <Tasks/>
-                </AdminRoute>}
-            />
-            <Route exact path="/admin/admin-resources"
-              element={
-                <AdminRoute
-                  permission={permission}
-                  security="adminresources"
-                >
-                  <AdminResources/>
-                </AdminRoute>}
-            />
-            <Route exact path="/admin/members"
-              element={
-                <AdminRoute
-                  permission={permission}
-                  security="members"
-                >
-                  <Members/>
-                </AdminRoute>}
-            />
-            <Route exact path="/admin/requests"
-              element={
-                <AdminRoute
-                  permission={permission}
-                  security="requests"
-                >
-                  <Requests/>
-                </AdminRoute>}
-            />
-            <Route exact path="/admin/statistics"
-              element={
-                <AdminRoute 
-                  permission={permission}
-                  security="statistics"
-                >
-                  <Statistics/>
-                </AdminRoute>}
-            />
-            <Route exact path="/admin/archives"
-              element={
-                <AdminRoute
-                  permission={permission}>
-                  <Archives/>
-                </AdminRoute>}
-            />
-            <Route exact path="/admin/corporatedatabase"
-              element={
-                <AdminRoute
-                  permission={permission}
-                  security="corporatedatabase">
-                    <CorporateDatabase/>
-                </AdminRoute>}
-            />
-            <Route exact path="/admin/reimbursements"
-              element={
-                <AdminRoute
-                  permission={permission}
-                  security="reimbursements">
-                    <Reimbursements/>
-                </AdminRoute>}
-            />
-            <Route exact path="/admin/receipts"
-              element={
-                <AdminRoute
-                permission={permission}
-                security="rental">
-                  <RentalAdmin/>
-                </AdminRoute>}
-            />
-          </Routes>
+        <MediaContextProvider>
+          <div style={{ minHeight: "calc(100vh - 66px" }}>
+            <MenuBar permission={permission} />
+            <Routes>
+              <Route exact path="/" element={<Home />} />
+              <Route exact path="/login"
+                element={
+                  <AuthRoute>
+                    <Login />
+                  </AuthRoute>}
+              />
+              <Route exact path="/register"
+                element={
+                  <AuthRoute>
+                    <Register />
+                  </AuthRoute>}
+              />
+              <Route exact path="/register/alumni" element={<RegisterAlumni />} />
+              <Route exact path="/about" element={<About />} />
+              <Route exact path="/alumni" element={<Alumni />} />
+              <Route exact path="/eboard" element={<EBoard />} />
+              <Route exact path="/devteam" element={<DevTeam />} />
+              <Route exact path="/shpejr" element={<ShpeJr />} />
+              <Route exact path="/sponsors" element={<Sponsors />} />
+              <Route exact path="/contactus" element={<ContactUs />} />
+              <Route exact path="/calendar" element={<MyCalendar />} />
+              <Route exact path="/resources" element={<Resources />} />
+              <Route exact path="/corporations"
+                element={
+                  <UserRoute>
+                    <Corporations />
+                  </UserRoute>}
+              />
+              <Route exact path="/reset/:token" element={<ResetPassword />} />
+              <Route exact path="/forgot" element={<ForgotPassword />} />
+              <Route exact path="/confirm/:id" element={<Confirm />} />
+              <Route exact
+                path="/profile"
+                element={
+                  <UserRoute>
+                    <Profile />
+                  </UserRoute>}
+              />
+              <Route exact path="/points"
+                element={
+                  <UserRoute>
+                    <Points />
+                  </UserRoute>}
+              />
+              <Route exact path="/alumnidirectory"
+                element={
+                  <UserRoute>
+                    <AlumniDirectory />
+                  </UserRoute>}
+              />
+              <Route exact path="/reimbursementrequest"
+                element={
+                  <UserRoute
+                    element={<ReimbursementRequest />}
+                    user={decodedToken}
+                  />}
+              />
+              <Route exact path="/shpeitonetwork"
+                element={
+                  <UserRoute>
+                    <ShpeitoNetwork />
+                  </UserRoute>}
+              />
+              <Route exact path="/mentorshpe"
+                element={
+                  <UserRoute>
+                    <MentorSHPE />
+                  </UserRoute>}
+              />
+              <Route exact path="/shperentals"
+                element={
+                  <UserRoute>
+                    <ShpeRentals />
+                  </UserRoute>}
+              />
+              <Route exact path="/admin"
+                element={
+                  <AdminRoute security="admin" permission={permission}>
+                    <Admin permission={permission} />
+                  </AdminRoute>}
+              />
+              <Route exact path="/admin/events"
+                element={
+                  <AdminRoute
+                    permission={permission}
+                    security="events">
+                    <Events />
+                  </AdminRoute>}
+              />
+              <Route exact path="/admin/tasks"
+                element={
+                  <AdminRoute
+                    permission={permission}
+                    security="tasks"
+                  >
+                    <Tasks />
+                  </AdminRoute>}
+              />
+              <Route exact path="/admin/admin-resources"
+                element={
+                  <AdminRoute
+                    permission={permission}
+                    security="adminresources"
+                  >
+                    <AdminResources />
+                  </AdminRoute>}
+              />
+              <Route exact path="/admin/members"
+                element={
+                  <AdminRoute
+                    permission={permission}
+                    security="members"
+                  >
+                    <Members />
+                  </AdminRoute>}
+              />
+              <Route exact path="/admin/requests"
+                element={
+                  <AdminRoute
+                    permission={permission}
+                    security="requests"
+                  >
+                    <Requests />
+                  </AdminRoute>}
+              />
+              <Route exact path="/admin/statistics"
+                element={
+                  <AdminRoute
+                    permission={permission}
+                    security="statistics"
+                  >
+                    <Statistics />
+                  </AdminRoute>}
+              />
+              <Route exact path="/admin/archives"
+                element={
+                  <AdminRoute
+                    permission={permission}>
+                    <Archives />
+                  </AdminRoute>}
+              />
+              <Route exact path="/admin/corporatedatabase"
+                element={
+                  <AdminRoute
+                    permission={permission}
+                    security="corporatedatabase">
+                    <CorporateDatabase />
+                  </AdminRoute>}
+              />
+              <Route exact path="/admin/reimbursements"
+                element={
+                  <AdminRoute
+                    permission={permission}
+                    security="reimbursements">
+                    <Reimbursements />
+                  </AdminRoute>}
+              />
+              <Route exact path="/admin/receipts"
+                element={
+                  <AdminRoute
+                    permission={permission}
+                    security="rental">
+                    <RentalAdmin />
+                  </AdminRoute>}
+              />
+            </Routes>
           </div>
           <Footer />
-      </MediaContextProvider>
-    </AuthProvider>
+        </MediaContextProvider>
+      </AuthProvider>
     </Router>
   );
 }


### PR DESCRIPTION
### Summary

Real User Monitoring has been integrated with React in Datadog. On the dashboard you're able to monitor load times & view individual user's paths across pages as long as they don't have adblock on. 

Logging has also been routed from Heroku to Datadog with HTTPS drain which should allow us to view errors in the server more closely than what Heroku provides. Drains can be viewed and added through the Heroku CLI.

The vision is to add RUM to the Android and iOS apps as well so we can obtain full breadth monitoring across our tech stacks.  This data can be used to see what patterns our members have and what potential spaces we can investigate to improve overall usage. Teams should hopefully collaborate within the next couple of months to implement both Datadog and the AWS migrations. 

We cannot monitor MongoDB Atlas with Datadog using the provided integration as it requires a M10 cluster at minimum, but if a page is taking a long time to query it displays as such (ex. Members page is indicated as poor performance)

### Reference

_Reference your Asana task here as shown below_

[Asana link](https://app.asana.com/0/1202843173947642/1203342704035634/f)

### Extra

_please add me (@mxqrz) as a reviewer. thank you!
